### PR TITLE
Implement Mailchimp backend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+config.json
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# landing_backend
+# Landing Backend
+
+This project provides a simple Flask server to store a Mailchimp API key and subscribe emails.
+
+## Endpoints
+
+- `POST /api_key` – Save a Mailchimp API key and list ID. JSON body must contain `api_key` and `list_id`.
+- `POST /subscribe` – Subscribe an email using the stored API key.
+
+## Running the server
+
+Install dependencies and start the app:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+## Tests
+
+Run unit tests with:
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,62 @@
+import json
+import os
+from flask import Flask, request, jsonify
+import requests
+
+CONFIG_FILE = os.environ.get('CONFIG_FILE', 'config.json')
+
+app = Flask(__name__)
+
+
+def load_config():
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, 'r') as f:
+            return json.load(f)
+    return {}
+
+
+def save_config(data):
+    with open(CONFIG_FILE, 'w') as f:
+        json.dump(data, f)
+
+
+@app.route('/api_key', methods=['POST'])
+def set_api_key():
+    data = request.get_json()
+    if not data or 'api_key' not in data or 'list_id' not in data:
+        return jsonify({'error': 'api_key and list_id required'}), 400
+    config = load_config()
+    config['api_key'] = data['api_key']
+    config['list_id'] = data['list_id']
+    save_config(config)
+    return jsonify({'status': 'saved'})
+
+
+@app.route('/subscribe', methods=['POST'])
+def subscribe():
+    data = request.get_json()
+    if not data or 'email' not in data:
+        return jsonify({'error': 'email required'}), 400
+
+    config = load_config()
+    api_key = config.get('api_key')
+    list_id = config.get('list_id')
+    if not api_key or not list_id:
+        return jsonify({'error': 'API key or list id not set'}), 500
+
+    email = data['email']
+    dc = api_key.split('-')[-1]
+    url = f'https://{dc}.api.mailchimp.com/3.0/lists/{list_id}/members'
+    payload = {
+        'email_address': email,
+        'status': 'subscribed'
+    }
+    auth = ('anystring', api_key)
+    response = requests.post(url, auth=auth, json=payload)
+    if response.status_code in (200, 201):
+        return jsonify({'status': 'subscribed'}), 200
+    return jsonify({'error': 'Mailchimp error', 'details': response.json()}), 400
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.0
+requests>=2.0
+pytest>=6.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,28 @@
+import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import os
+import json
+from unittest.mock import patch
+from app import app, save_config, CONFIG_FILE
+
+
+def test_set_api_key(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr('app.CONFIG_FILE', str(config_file))
+    with app.test_client() as client:
+        resp = client.post('/api_key', json={'api_key': 'key-us1', 'list_id': '123'})
+        assert resp.status_code == 200
+        assert config_file.exists()
+
+
+@patch('app.requests.post')
+def test_subscribe_with_mock(mock_post, tmp_path, monkeypatch):
+    config_file = tmp_path / "config.json"
+    monkeypatch.setattr('app.CONFIG_FILE', str(config_file))
+    save_config({'api_key': 'key-us1', 'list_id': '123'})
+    mock_post.return_value.status_code = 200
+    mock_post.return_value.json.return_value = {}
+
+    with app.test_client() as client:
+        resp = client.post('/subscribe', json={'email': 'test@example.com'})
+        assert resp.status_code == 200
+        mock_post.assert_called()


### PR DESCRIPTION
## Summary
- create Flask server to store Mailchimp API key and subscribe emails
- add unit tests covering API key saving and email subscription
- document endpoints and usage

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684806b883b08321b70c97d09e45b73f