### PR TITLE
Add snapshot endpoint for truncated trade metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project provides a simple Flask server to store a Mailchimp API key and sub
 - `POST /subscribe` – Subscribe an email using the stored API key.
 - `POST /unsubscribe` – Remove an email from the mailing list.
 - `POST /status` – Return the current subscription status for an email.
+- `GET /snapshot` – Proxy snapshot data and truncate numeric values to two decimals. If the upstream service is unreachable, returns zeros for all fields.
 
 ## Running the server
 


### PR DESCRIPTION
## Summary
- return zero snapshot when upstream call fails
- add test for snapshot failure and document fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68905d80a050832194b7eb31bb6e54dc